### PR TITLE
9 double tap on mobile zooms

### DIFF
--- a/public/wordle/script.js
+++ b/public/wordle/script.js
@@ -138,6 +138,24 @@ window.addEventListener("load", (event) => {
 	}
 });
 
+
+/* If CSS modification isn't enough to fix the double-tap issue on mobile, this would prevent double-tapping on keys.
+	Stills enable zooming on page! */
+
+// document.querySelectorAll('.key').forEach(button => {
+// 	let lastTap = 0;
+
+// 	button.addEventListener('touchend', (e) => {
+// 		const currentTime = new Date().getTime();
+// 		const tapLength = currentTime - lastTap;
+
+// 		if (tapLength < 500 && tapLength > 0) {
+// 			e.preventDefault();
+// 		}
+// 		lastTap = currentTime;
+// 	});
+// });
+
 function showHardModeError(message) {
 	const errorDiv = document.createElement('div');
 	errorDiv.className = 'hard-mode-error';
@@ -235,18 +253,18 @@ function setKeyboardTileColor(key, keyState) {
 }
 
 function shakeCurrentRow() {
-    for (let x = 1; x <= 5; x++) {
-        const tile = document.querySelector(`#wordle-${position.y}-${x}`);
-        tile.classList.remove('tile-delete');
-        void tile.offsetWidth;
-        tile.classList.add('tile-delete');
-        setTimeout(() => {
-            tile.classList.remove('tile-delete');
-        }, 150);
-    }
-    setTimeout(() => {
-        pause_event = false;
-    }, 150);
+	for (let x = 1; x <= 5; x++) {
+		const tile = document.querySelector(`#wordle-${position.y}-${x}`);
+		tile.classList.remove('tile-delete');
+		void tile.offsetWidth;
+		tile.classList.add('tile-delete');
+		setTimeout(() => {
+			tile.classList.remove('tile-delete');
+		}, 150);
+	}
+	setTimeout(() => {
+		pause_event = false;
+	}, 150);
 }
 
 function setLetter(pos, letter) {
@@ -507,134 +525,134 @@ function openPopUpLoose() {
 }
 
 function generateShareText() {
-    const date = new Date();
-    const dateStr = `${date.getDate().toString().padStart(2, '0')}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getFullYear()}`;
+	const date = new Date();
+	const dateStr = `${date.getDate().toString().padStart(2, '0')}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getFullYear()}`;
 
-    let shareText = `42 Wordle ${dateStr} ${position.y - 1}/6`;
-    if (gameMode === 'hard') {
-        shareText += ' (Hard Mode)';
-    }
-    shareText += '\n\n';
+	let shareText = `42 Wordle ${dateStr} ${position.y - 1}/6`;
+	if (gameMode === 'hard') {
+		shareText += ' (Hard Mode)';
+	}
+	shareText += '\n\n';
 
-    for (let row = 1; row < position.y; row++) {
-        let rowText = '';
-        for (let col = 1; col <= 5; col++) {
-            const tile = document.querySelector(`#wordle-${row}-${col}`);
+	for (let row = 1; row < position.y; row++) {
+		let rowText = '';
+		for (let col = 1; col <= 5; col++) {
+			const tile = document.querySelector(`#wordle-${row}-${col}`);
 
-            if (tile.classList.contains('correct')) {
-                rowText += '🟩';
-            } else if (tile.classList.contains('present')) {
-                rowText += '🟨';
-            } else if (tile.classList.contains('absent')) {
-                rowText += '⬛';
-            } else {
-                rowText += '⬜';
-            }
-        }
-        shareText += rowText + '\n';
-    }
+			if (tile.classList.contains('correct')) {
+				rowText += '🟩';
+			} else if (tile.classList.contains('present')) {
+				rowText += '🟨';
+			} else if (tile.classList.contains('absent')) {
+				rowText += '⬛';
+			} else {
+				rowText += '⬜';
+			}
+		}
+		shareText += rowText + '\n';
+	}
 
-    const timeInSeconds = ((Date.now() - start_time) / 1000).toFixed(1);
-    shareText += `\n⏱️ ${timeInSeconds}s`;
-    shareText += `\n🎮 ${window.location.origin}`;
+	const timeInSeconds = ((Date.now() - start_time) / 1000).toFixed(1);
+	shareText += `\n⏱️ ${timeInSeconds}s`;
+	shareText += `\n🎮 ${window.location.origin}`;
 
-    return (shareText.trim());
+	return (shareText.trim());
 }
 
 async function copyToClipboard(text) {
-    try {
-        await navigator.clipboard.writeText(text);
-        return true;
-    } catch (err) {
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.position = 'fixed';
-        textArea.style.left = '-999999px';
-        textArea.style.top = '-999999px';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-    }
+	try {
+		await navigator.clipboard.writeText(text);
+		return true;
+	} catch (err) {
+		const textArea = document.createElement('textarea');
+		textArea.value = text;
+		textArea.style.position = 'fixed';
+		textArea.style.left = '-999999px';
+		textArea.style.top = '-999999px';
+		document.body.appendChild(textArea);
+		textArea.focus();
+		textArea.select();
+	}
 }
 
 function displayShareResult() {
-    const shareResultDiv = document.getElementById('shareResult');
-    shareResultDiv.innerHTML = '';
+	const shareResultDiv = document.getElementById('shareResult');
+	shareResultDiv.innerHTML = '';
 
-    for (let row = 1; row < position.y; row++) {
-        const rowDiv = document.createElement('div');
-        rowDiv.style.marginBottom = '2px';
+	for (let row = 1; row < position.y; row++) {
+		const rowDiv = document.createElement('div');
+		rowDiv.style.marginBottom = '2px';
 
-        for (let col = 1; col <= 5; col++) {
-            const tile = document.querySelector(`#wordle-${row}-${col}`);
-            let emoji = '⬜';
+		for (let col = 1; col <= 5; col++) {
+			const tile = document.querySelector(`#wordle-${row}-${col}`);
+			let emoji = '⬜';
 
-            if (tile.classList.contains('correct')) {
-                emoji = '🟩';
-            } else if (tile.classList.contains('present')) {
-                emoji = '🟨';
-            } else if (tile.classList.contains('absent')) {
-                emoji = '⬛';
-            }
+			if (tile.classList.contains('correct')) {
+				emoji = '🟩';
+			} else if (tile.classList.contains('present')) {
+				emoji = '🟨';
+			} else if (tile.classList.contains('absent')) {
+				emoji = '⬛';
+			}
 
-            const span = document.createElement('span');
-            span.textContent = emoji;
-            span.style.fontSize = '1.5rem';
-            span.style.marginRight = '2px';
-            rowDiv.appendChild(span);
-        }
+			const span = document.createElement('span');
+			span.textContent = emoji;
+			span.style.fontSize = '1.5rem';
+			span.style.marginRight = '2px';
+			rowDiv.appendChild(span);
+		}
 
-        shareResultDiv.appendChild(rowDiv);
-    }
+		shareResultDiv.appendChild(rowDiv);
+	}
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    const shareButton = document.getElementById('shareButton');
-    const copyNotification = document.getElementById('copyNotification');
-    const modal = document.getElementById('gameOverModal');
-    const closeBtn = document.querySelector('.close');
+	const shareButton = document.getElementById('shareButton');
+	const copyNotification = document.getElementById('copyNotification');
+	const modal = document.getElementById('gameOverModal');
+	const closeBtn = document.querySelector('.close');
 
-    shareButton.addEventListener('click', async function() {
-        const shareText = generateShareText();
-        const success = await copyToClipboard(shareText);
+	shareButton.addEventListener('click', async function() {
+		const shareText = generateShareText();
+		const success = await copyToClipboard(shareText);
 
-        if (success) {
-            copyNotification.classList.add('show');
+		if (success) {
+			copyNotification.classList.add('show');
 
-            setTimeout(() => {
-                copyNotification.classList.remove('show');
-            }, 2000);
+			setTimeout(() => {
+				copyNotification.classList.remove('show');
+			}, 2000);
 
-            const originalHTML = shareButton.innerHTML;
-            shareButton.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg> Copied!';
-            shareButton.style.backgroundColor = '#5fa35a';
+			const originalHTML = shareButton.innerHTML;
+			shareButton.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg> Copied!';
+			shareButton.style.backgroundColor = '#5fa35a';
 
-            setTimeout(() => {
-                shareButton.innerHTML = originalHTML;
-                shareButton.style.backgroundColor = '';
-            }, 2000);
-        }
-    });
+			setTimeout(() => {
+				shareButton.innerHTML = originalHTML;
+				shareButton.style.backgroundColor = '';
+			}, 2000);
+		}
+	});
 
-    closeBtn.addEventListener('click', function() {
-        modal.classList.add('hide-modal');
-    });
+	closeBtn.addEventListener('click', function() {
+		modal.classList.add('hide-modal');
+	});
 
-    window.addEventListener('click', function(event) {
-        if (event.target === modal) {
-            modal.classList.add('hide-modal');
-        }
-    });
+	window.addEventListener('click', function(event) {
+		if (event.target === modal) {
+			modal.classList.add('hide-modal');
+		}
+	});
 });
 
 const originalOpenPopUpWin = openPopUpWin;
 openPopUpWin = function() {
-    originalOpenPopUpWin();
-    displayShareResult();
+	originalOpenPopUpWin();
+	displayShareResult();
 };
 
 const originalOpenPopUpLoose = openPopUpLoose;
 openPopUpLoose = function() {
-    originalOpenPopUpLoose();
-    displayShareResult();
+	originalOpenPopUpLoose();
+	displayShareResult();
 };

--- a/public/wordle/style.css
+++ b/public/wordle/style.css
@@ -130,6 +130,7 @@ h1 {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+    touch-action: manipulation;
 }
 
 .keyboard-r {
@@ -147,6 +148,10 @@ h1 {
 	border-radius: 4px;
 	cursor: pointer;
 	margin: 3px 2px;
+    touch-action: manipulation;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .key.enter,

--- a/public/wordle/style.css
+++ b/public/wordle/style.css
@@ -130,7 +130,7 @@ h1 {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-    touch-action: manipulation;
+	touch-action: manipulation;
 }
 
 .keyboard-r {
@@ -148,10 +148,10 @@ h1 {
 	border-radius: 4px;
 	cursor: pointer;
 	margin: 3px 2px;
-    touch-action: manipulation;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    user-select: none;
+	touch-action: manipulation;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	user-select: none;
 }
 
 .key.enter,
@@ -189,34 +189,34 @@ h1 {
 }
 
 .leaderboards {
-    display: flex;
-    justify-content: center;
-    gap: 2rem;
-    margin: 2rem 0;
+	display: flex;
+	justify-content: center;
+	gap: 2rem;
+	margin: 2rem 0;
 }
 .leaderboard {
-    background: #222;
-    border-radius: 10px;
-    padding: 1rem 2rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-    min-width: 180px;
+	background: #222;
+	border-radius: 10px;
+	padding: 1rem 2rem;
+	box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+	min-width: 180px;
 }
 .leaderboard h2 {
-    font-size: 1.2rem;
-    margin-bottom: 0.5rem;
-    color: #ffd700;
-    text-align: center;
+	font-size: 1.2rem;
+	margin-bottom: 0.5rem;
+	color: #ffd700;
+	text-align: center;
 }
 .leaderboard ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+	list-style: none;
+	padding: 0;
+	margin: 0;
 }
 .leaderboard li {
-    padding: 0.2rem 0;
-    display: flex;
-    justify-content: space-between;
-    color: #fff;
+	padding: 0.2rem 0;
+	display: flex;
+	justify-content: space-between;
+	color: #fff;
 }
 
 .center-li {
@@ -228,30 +228,30 @@ h1 {
 }
 
 .leaderboard .score {
-    color: #ffd700;
-    font-weight: bold;
+	color: #ffd700;
+	font-weight: bold;
 }
 
 .back-to-home {
-    position: fixed;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1000;
+	position: fixed;
+	bottom: 2rem;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 1000;
 }
 
 .home-link {
-    color: #ffffff;
-    text-decoration: none;
-    font-family: 'Courier New', monospace;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: opacity 0.3s ease;
+	color: #ffffff;
+	text-decoration: none;
+	font-family: 'Courier New', monospace;
+	font-size: 1rem;
+	cursor: pointer;
+	transition: opacity 0.3s ease;
 }
 
 .home-link:hover {
-    opacity: 0.7;
-    text-decoration: underline;
+	opacity: 0.7;
+	text-decoration: underline;
 }
 
 .hide-modal {
@@ -259,170 +259,170 @@ h1 {
 }
 
 .modal {
-    position: fixed;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.8);
-    animation: fadeIn 0.3s ease;
+	position: fixed;
+	z-index: 1000;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.8);
+	animation: fadeIn 0.3s ease;
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+	from { opacity: 0; }
+	to { opacity: 1; }
 }
 
 .modal-content {
-    background-color: #1a1a1b;
-    margin: 10% auto;
-    padding: 2rem;
-    border: 2px solid #3a3a3c;
-    border-radius: 10px;
-    width: 90%;
-    max-width: 400px;
-    text-align: center;
-    position: relative;
-    animation: slideIn 0.3s ease;
+	background-color: #1a1a1b;
+	margin: 10% auto;
+	padding: 2rem;
+	border: 2px solid #3a3a3c;
+	border-radius: 10px;
+	width: 90%;
+	max-width: 400px;
+	text-align: center;
+	position: relative;
+	animation: slideIn 0.3s ease;
 }
 
 @keyframes slideIn {
-    from {
-        transform: translateY(-50px);
-        opacity: 0;
-    }
-    to {
-        transform: translateY(0);
-        opacity: 1;
-    }
+	from {
+		transform: translateY(-50px);
+		opacity: 0;
+	}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+	}
 }
 
 .close {
-    color: #818384;
-    position: absolute;
-    right: 1rem;
-    top: 1rem;
-    font-size: 28px;
-    font-weight: bold;
-    cursor: pointer;
-    transition: color 0.2s;
+	color: #818384;
+	position: absolute;
+	right: 1rem;
+	top: 1rem;
+	font-size: 28px;
+	font-weight: bold;
+	cursor: pointer;
+	transition: color 0.2s;
 }
 
 .close:hover,
 .close:focus {
-    color: #ffffff;
+	color: #ffffff;
 }
 
 #modalTitle {
-    color: #ffffff;
-    margin-bottom: 1rem;
-    font-size: 1.8rem;
+	color: #ffffff;
+	margin-bottom: 1rem;
+	font-size: 1.8rem;
 }
 
 #modalTitle.win {
-    color: #538d4e;
+	color: #538d4e;
 }
 
 #modalTitle.lose {
-    color: #ff6b6b;
+	color: #ff6b6b;
 }
 
 #gameStats {
-    display: flex;
-    justify-content: center;
-    gap: 2rem;
-    margin-bottom: 1.5rem;
+	display: flex;
+	justify-content: center;
+	gap: 2rem;
+	margin-bottom: 1.5rem;
 }
 
 .stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 .stat-label {
-    color: #818384;
-    font-size: 0.9rem;
-    margin-bottom: 0.3rem;
+	color: #818384;
+	font-size: 0.9rem;
+	margin-bottom: 0.3rem;
 }
 
 .stat span:last-child {
-    color: #ffffff;
-    font-size: 1.2rem;
-    font-weight: bold;
+	color: #ffffff;
+	font-size: 1.2rem;
+	font-weight: bold;
 }
 
 #shareResult {
-    margin: 1.5rem 0;
-    font-family: monospace;
-    line-height: 1.2;
-    font-size: 1.2rem;
+	margin: 1.5rem 0;
+	font-family: monospace;
+	line-height: 1.2;
+	font-size: 1.2rem;
 }
 
 .share-btn {
-    background-color: #538d4e;
-    color: white;
-    border: none;
-    padding: 0.8rem 1.5rem;
-    border-radius: 5px;
-    font-size: 1rem;
-    font-weight: bold;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    transition: all 0.2s;
+	background-color: #538d4e;
+	color: white;
+	border: none;
+	padding: 0.8rem 1.5rem;
+	border-radius: 5px;
+	font-size: 1rem;
+	font-weight: bold;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	transition: all 0.2s;
 }
 
 .share-btn:hover {
-    background-color: #5fa35a;
-    transform: translateY(-1px);
+	background-color: #5fa35a;
+	transform: translateY(-1px);
 }
 
 .share-btn:active {
-    transform: translateY(0);
+	transform: translateY(0);
 }
 
 .copy-notification {
-    position: absolute;
-    bottom: -3rem;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #538d4e;
-    color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 5px;
-    opacity: 0;
-    transition: opacity 0.3s;
-    pointer-events: none;
+	position: absolute;
+	bottom: -3rem;
+	left: 50%;
+	transform: translateX(-50%);
+	background-color: #538d4e;
+	color: white;
+	padding: 0.5rem 1rem;
+	border-radius: 5px;
+	opacity: 0;
+	transition: opacity 0.3s;
+	pointer-events: none;
 }
 
 .copy-notification.show {
-    opacity: 1;
+	opacity: 1;
 }
 
 .hard-mode-error {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: #b59f3b;
-    color: white;
-    padding: 1rem 2rem;
-    border-radius: 8px;
-    font-weight: bold;
-    z-index: 1001;
-    animation: errorFadeIn 0.3s ease;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background-color: #b59f3b;
+	color: white;
+	padding: 1rem 2rem;
+	border-radius: 8px;
+	font-weight: bold;
+	z-index: 1001;
+	animation: errorFadeIn 0.3s ease;
 }
 
 @keyframes errorFadeIn {
-    from {
-        opacity: 0;
-        transform: translate(-50%, -50%) scale(0.8);
-    }
-    to {
-        opacity: 1;
-        transform: translate(-50%, -50%) scale(1);
-    }
+	from {
+		opacity: 0;
+		transform: translate(-50%, -50%) scale(0.8);
+	}
+	to {
+		opacity: 1;
+		transform: translate(-50%, -50%) scale(1);
+	}
 }


### PR DESCRIPTION
This pull request addresses a double-tap issue on mobile devices for the Wordle game by modifying the CSS and adding a commented-out JavaScript solution as a fallback. The changes aim to improve the mobile user experience while maintaining zoom functionality.

### CSS Changes to Address Double-Tap Issue:
* Added `touch-action: manipulation` to the `h1` and `.key` elements to prevent unintended double-tap behavior on mobile devices.
* Added `-webkit-touch-callout: none`, `-webkit-user-select: none`, and `user-select: none` to the `.key` elements to disable text selection and callout menus on mobile devices.

### JavaScript Fallback (Commented Out):
* Introduced a commented-out JavaScript solution to prevent double-tapping on `.key` elements by detecting rapid consecutive taps. This fallback is included in case CSS modifications are insufficient.

### Issue
* Those solutions should be enough to close #9 